### PR TITLE
Non-color tokens export

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,8 @@ import { emit, on, showUI } from '@create-figma-plugin/utilities';
 import { kebabCase } from 'change-case';
 import chroma from 'chroma-js';
 
-const COLORS_COLLECTION_NAME = 'Lvl 01 - Root'
+const ROOT_COLLECTION_NAME = 'Lvl 01 - Root'
+const STYLE_COLLECTION_NAME = 'Lvl 02 - Style'
 const MODE_COLLECTION_NAME = 'Lvl 03 (A) - Mode'
 const COMPONENTS_COLLECTION_NAME = 'Lvl 04 - Component'
 
@@ -38,7 +39,7 @@ export default function () {
   on('GENERATE_COLOR_VARIABLES', async () => {
     const tokens = [];
     const collections = await figma.variables.getLocalVariableCollectionsAsync();
-    const colorsCollection = collections.filter(({ name }) => name === COLORS_COLLECTION_NAME)?.[0];
+    const colorsCollection = collections.filter(({ name }) => name === ROOT_COLLECTION_NAME)?.[0];
     const mode = colorsCollection?.modes?.[0]?.modeId; // Only one mode is supported for Root level
 
     for (const variableId of colorsCollection?.variableIds || []) {
@@ -77,7 +78,7 @@ export default function () {
         const value = variable.valuesByMode[mode]
 
         if ((value as VariableAlias)?.type === 'VARIABLE_ALIAS') {
-          const targetVariable = await getNestedVariable((value as VariableAlias)?.id, COLORS_COLLECTION_NAME);
+          const targetVariable = await getNestedVariable((value as VariableAlias)?.id, ROOT_COLLECTION_NAME);
 
           tokens.push({
             token: name,
@@ -116,6 +117,136 @@ export default function () {
     }
 
     emit('GENERATED_COMPONENT_VARIABLES', { tokens });
+  });
+
+  on('GENERATE_OTHER_VARIABLES', async () => {
+    const tokens = [];
+    const collections = await figma.variables.getLocalVariableCollectionsAsync();
+    const stylesCollection = collections.filter(({ name }) => name === STYLE_COLLECTION_NAME)?.[0];
+    const rootCollection = collections.filter(({ name }) => name === ROOT_COLLECTION_NAME)?.[0];
+    const rootMode = rootCollection?.modes?.[0]?.modeId; // Only one mode is supported for Root level
+    const stylesMode = stylesCollection?.modes?.[0]?.modeId; // Only one mode is supported for Root level
+
+    let fontsStoredCount = 0;
+
+    tokens.push('/* Font Families */');
+    for (const variableId of rootCollection?.variableIds || []) {
+      const variable = await figma.variables.getVariableByIdAsync(variableId);
+
+      if (variable?.name?.startsWith('Typography/Family')) {
+        if (variable?.name?.toLowerCase()?.includes('mono')) {
+          tokens.push({
+            token: 'font-mono',
+            value: `"${variable?.valuesByMode[rootMode]}", monospace`
+          })
+        } else if (fontsStoredCount === 0) {
+          tokens.push({
+            token: 'font-sans',
+            value: `"${variable?.valuesByMode[rootMode]}", sans-serif`
+          });
+        } else if (fontsStoredCount === 1) {
+          tokens.push({
+            token: 'font-serif',
+            value: `"${variable?.valuesByMode[rootMode]}", serif`
+          });
+        }
+        fontsStoredCount++;
+      }
+    }
+
+    tokens.push('');
+    tokens.push('/* Font Sizes */');
+    for (const variableId of stylesCollection?.variableIds || []) {
+      const variable = await figma.variables.getVariableByIdAsync(variableId);
+
+      if (variable?.name?.startsWith('Typography/Font Size')) {
+        const name = variable?.name.split('/')?.pop()?.toLowerCase();
+        const value = variable.valuesByMode[stylesMode]
+
+        if ((value as VariableAlias)?.type === 'VARIABLE_ALIAS') {
+          const targetVariable = await getNestedVariable((value as VariableAlias)?.id, ROOT_COLLECTION_NAME);
+          const fontSize = targetVariable?.valuesByMode?.[rootMode] as number;
+          tokens.push({
+            token: `text-${name}`,
+            value: `${fontSize / 16}rem`,
+          })
+        }
+      }
+    }
+
+    tokens.push('');
+    tokens.push('/* Line Heights */');
+    for (const variableId of stylesCollection?.variableIds || []) {
+      const variable = await figma.variables.getVariableByIdAsync(variableId);
+
+      if (variable?.name?.startsWith('Typography/Line Height')) {
+        const name = variable?.name.split('/')?.pop()?.toLowerCase();
+        const value = variable.valuesByMode[stylesMode]
+
+        if ((value as VariableAlias)?.type === 'VARIABLE_ALIAS') {
+          const targetVariable = await getNestedVariable((value as VariableAlias)?.id, ROOT_COLLECTION_NAME);
+          const fontSize = targetVariable?.valuesByMode?.[rootMode] as number;
+          tokens.push({
+            token: `text-${name}--line-height`,
+            value: `${fontSize / 16}rem`,
+          })
+        }
+      }
+    }
+
+    tokens.push('');
+    tokens.push('/* Corner Radius */');
+    for (const variableId of stylesCollection?.variableIds || []) {
+      const variable = await figma.variables.getVariableByIdAsync(variableId);
+
+      if (variable?.name?.startsWith('Corner Radius')) {
+        const name = variable?.name.split('/')?.pop()?.toLowerCase();
+        const value = variable.valuesByMode[stylesMode]
+
+        if ((value as VariableAlias)?.type === 'VARIABLE_ALIAS') {
+          const targetVariable = await getNestedVariable((value as VariableAlias)?.id, ROOT_COLLECTION_NAME);
+          const fontSize = targetVariable?.valuesByMode?.[rootMode] as number;
+          tokens.push({
+            token: `radius-${name}`,
+            value: `${fontSize / 16}rem`,
+          })
+        }
+      }
+    }
+
+    tokens.push('');
+    tokens.push('/* Blur */');
+    for (const variableId of rootCollection?.variableIds || []) {
+      const variable = await figma.variables.getVariableByIdAsync(variableId);
+
+      if (variable?.name?.startsWith('Effects/Blur')) {
+        const name = variable?.name.split('/')?.pop()?.toLowerCase();
+        const value = variable.valuesByMode[rootMode] as number;
+
+        tokens.push({
+          token: `blur-${name}`,
+          value: `${value / 16}rem`,
+        })
+      }
+    }
+
+    tokens.push('');
+    tokens.push('/* Shadow */');
+    for (const variableId of rootCollection?.variableIds || []) {
+      const variable = await figma.variables.getVariableByIdAsync(variableId);
+
+      if (variable?.name?.startsWith('Effects/Shadow')) {
+        const name = variable?.name.split('/')?.pop()?.toLowerCase();
+        const value = variable.valuesByMode[rootMode] as number;
+
+        tokens.push({
+          token: `drop-shadow-${name}`,
+          value: `${value / 16}rem`,
+        })
+      }
+    }
+
+    emit('GENERATED_OTHER_VARIABLES', { tokens });
   });
 
   showUI({ height: 500, width: 400 });

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -22,20 +22,25 @@ function Plugin() {
   const [colorVariables, setColorVariables] = useState('');
   const [modeVariables, setModeVariables] = useState('');
   const [componentVariables, setComponentVariables] = useState('');
+  const [otherVariables, setOtherVariables] = useState('');
   const [modes, setModes] = useState<Record<string, string>>({});
   const [selectedMode, setSelectedMode] = useState<string | null>(null);
   const [colorsCopyButtonText, setColorsCopyButtonText] = useState(COPY_TITLE);
   const [modeCopyButtonText, setModeCopyButtonText] = useState(COPY_TITLE);
   const [componentCopyButtonText, setComponentCopyButtonText] =
     useState(COPY_TITLE);
+  const [otherCopyButtonText, setOtherCopyButtonText] =
+    useState(COPY_TITLE);
 
   const generateVariablesHandler = useCallback(() => {
     setColorVariables(GENERATING_TITLE);
     setModeVariables(GENERATING_TITLE);
     setComponentVariables(GENERATING_TITLE);
+    setOtherVariables(GENERATING_TITLE);
     emit('GENERATE_COLOR_VARIABLES');
     emit('GENERATE_MODE_VARIABLES', { mode: selectedMode });
     emit('GENERATE_COMPONENT_VARIABLES');
+    emit('GENERATE_OTHER_VARIABLES');
   }, [selectedMode]);
 
   const copyColors = useCallback(() => {
@@ -54,6 +59,12 @@ function Plugin() {
     copy(componentVariables);
     setComponentCopyButtonText(COPIED_TITLE);
     setTimeout(() => setComponentCopyButtonText(COPY_TITLE), 2000);
+  }, [componentVariables]);
+
+  const copyTypography = useCallback(() => {
+    copy(otherVariables);
+    setOtherCopyButtonText(COPIED_TITLE);
+    setTimeout(() => setOtherCopyButtonText(COPY_TITLE), 2000);
   }, [componentVariables]);
 
   useEffect(() => {
@@ -86,6 +97,22 @@ function Plugin() {
         setComponentVariables(
           tokens
             .map(({ token, value }) => `--color-${token}: var(--${value});`)
+            .join(`\n`),
+        );
+      },
+    );
+    on(
+      'GENERATED_OTHER_VARIABLES',
+      ({ tokens }: { tokens: ({ token: string; value: string } | string)[] }) => {
+        setOtherVariables(
+          tokens
+            .map((val) => {
+              if (typeof val === 'string') {
+                return val;
+              } else {
+                return`--${val.token}: ${val.value};`
+              }
+            })
             .join(`\n`),
         );
       },
@@ -153,7 +180,7 @@ function Plugin() {
         {modeCopyButtonText}
       </Button>
       <VerticalSpace space="large" />
-      Component variables:
+        Component variables:
       <VerticalSpace space="extraSmall" />
       <div class={styles.container}>
         <TextboxMultiline
@@ -172,6 +199,27 @@ function Plugin() {
         onClick={copyTokens}
       >
         {componentCopyButtonText}
+      </Button>
+      <VerticalSpace space="large" />
+        Other variables:
+      <VerticalSpace space="extraSmall" />
+      <div class={styles.container}>
+        <TextboxMultiline
+          rows={10}
+          placeholder="Click on Generate"
+          value={otherVariables}
+        />
+      </div>
+      <VerticalSpace space="small" />
+      <Button
+        disabled={
+          !otherVariables ||
+          otherVariables === GENERATING_TITLE ||
+          otherCopyButtonText === COPIED_TITLE
+        }
+        onClick={copyTypography}
+      >
+        {otherCopyButtonText}
       </Button>
       <VerticalSpace space="small" />
     </Container>

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -61,11 +61,11 @@ function Plugin() {
     setTimeout(() => setComponentCopyButtonText(COPY_TITLE), 2000);
   }, [componentVariables]);
 
-  const copyTypography = useCallback(() => {
+  const copyOther = useCallback(() => {
     copy(otherVariables);
     setOtherCopyButtonText(COPIED_TITLE);
     setTimeout(() => setOtherCopyButtonText(COPY_TITLE), 2000);
-  }, [componentVariables]);
+  }, [otherVariables]);
 
   useEffect(() => {
     emit('LOAD_MODES');
@@ -217,7 +217,7 @@ function Plugin() {
           otherVariables === GENERATING_TITLE ||
           otherCopyButtonText === COPIED_TITLE
         }
-        onClick={copyTypography}
+        onClick={copyOther}
       >
         {otherCopyButtonText}
       </Button>


### PR DESCRIPTION
<img width="420" height="563" alt="Screenshot 2025-08-21 at 14 48 31" src="https://github.com/user-attachments/assets/93f3751a-6194-420b-9b31-6766119389cb" />

Export example:

/* Font Families */
--font-sans: "Proxima Nova", sans-serif;
--font-serif: "Blender Pro", serif;
--font-mono: "Share Tech Mono", monospace;

/* Font Sizes */
--text-xxs: 0.625rem;
--text-xs: 0.75rem;
--text-sm: 0.875rem;
--text-base: 1rem;
--text-lg: 1.25rem;
--text-xl: 1.375rem;
--text-2xl: 1.5rem;
--text-3xl: 1.625rem;
--text-4xl: 1.75rem;
--text-5xl: 1.875rem;
--text-6xl: 2rem;
--text-7xl: 2.25rem;
--text-8xl: 2.5rem;
--text-9xl: 3.75rem;

/* Line Heights */
--text-xxs--line-height: 0.75rem;
--text-xs--line-height: 0.875rem;
--text-sm--line-height: 1.125rem;
--text-base--line-height: 1.5rem;
--text-lg--line-height: 1.5rem;
--text-xl--line-height: 1.75rem;
--text-2xl--line-height: 1.75rem;
--text-3xl--line-height: 1.75rem;
--text-4xl--line-height: 2rem;
--text-5xl--line-height: 2.125rem;
--text-6xl--line-height: 2.25rem;
--text-7xl--line-height: 2.5rem;
--text-8xl--line-height: 3rem;
--text-9xl--line-height: 4.5rem;

/* Corner Radius */
--radius-primary: 0.375rem;
--radius-lg: 0.75rem;
--radius-sm: 0.25rem;
--radius-pill: 6.25rem;
--radius-sharp: 0rem;

/* Blur */
--blur-0: 0rem;
--blur-half: 0.03125rem;
--blur-1: 0.0625rem;
--blur-2: 0.125rem;
--blur-4: 0.25rem;
--blur-6: 0.375rem;
--blur-8: 0.5rem;
--blur-10: 0.625rem;
--blur-12: 0.75rem;
--blur-14: 0.875rem;
--blur-16: 1rem;
--blur-18: 1.125rem;
--blur-20: 1.25rem;
--blur-50: 3.125rem;
--blur-100: 6.25rem;

/* Shadow */
--drop-shadow-0: 0rem;
--drop-shadow-1: 0.0625rem;
--drop-shadow-2: 0.125rem;
--drop-shadow-4: 0.25rem;
--drop-shadow-6: 0.375rem;
--drop-shadow-8: 0.5rem;
--drop-shadow-10: 0.625rem;
--drop-shadow-12: 0.75rem;
--drop-shadow-14: 0.875rem;
--drop-shadow-16: 1rem;
--drop-shadow-18: 1.125rem;
--drop-shadow-20: 1.25rem;
--drop-shadow-40: 2.5rem;
--drop-shadow-60: 3.75rem;

