### PR TITLE
GOOD-942: Add ability to CSS bundle export & bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,56 @@ Plugin utilities to super charge your dev work for [reablocks](https://github.co
 
 ## Features
 
-- CSS Token Generator: Generate Reablock compatible json from Figma Style variables
+- **Export Styles**: One-click generation of a ready-to-use CSS bundle (zip) containing all theme files
+- **Inspect Variables**: Browse and copy individual token sections (root, mode, component, other)
 
-## CSS Token Generator Usage
+## Export Styles (ready-to-use CSS bundle)
+
+The plugin's primary action exports a zip of CSS files you can drop straight into a reablocks-based project. No manual copy/paste required.
 
 ### Pre-requisite
 
-- You should have style created for all colors that you want to use in the project
-- You should use following naming convention to assign style property to your colors
+The Figma file must use the Unify Design System variable collections (`Lvl 01 - Root`, `Lvl 02 - Style`, `Lvl 03 (A) - Mode`, `Lvl 03 (C) - Dimension`, `Lvl 04 - Component`). If the plugin can't find these, it shows a "Heads up" screen pointing at [unifydesignsystem.com](https://unifydesignsystem.com).
 
-  - E.g.: 'Primary', 'Brand', 'Primary/100', 'Brand/title black 100'``
+### Running the export
 
-### Running Plugin
+1. Open the Figma file in the Figma desktop app.
+2. Run the **Reablocks Figma Plugin** from the Quick Actions menu (`CMD + P` / `Ctrl + P`).
+3. (Optional) If your file has multiple **Style** modes, pick the one you want to export from the **Style** dropdown.
+4. Pick the **Default theme** (`Dark` or `Light`) — this is the theme that will be applied at `:root` without needing a wrapping class.
+5. Click **Export Styles**. Your browser downloads `<file-name>-styles.zip`.
 
-- Go to the Figma design file where you want to use the plugin
-- Use `CMD + p` to open quick menu
-- Search for new plugins using "Find More plugins option" and search for "Reablocks Figma Plugin"
-- Once found, click on run plugin, it will open a popup
-- Click on "Generate Tokens"
-- Click on "Copy Colors" to grab all of color tokens
-- Use the copied tokens in your project's color palette
-- Click on "Copy Themes" to grab all of your design tokens for your theme
-- Use the copied tokens in your project's theme
+### What's in the zip
+
+| File | Purpose |
+| --- | --- |
+| `index.css` | Entry point — imports the other files in the correct order. |
+| `common.css` | Base resets, font smoothing, `:root` body styles, tooltip vars. |
+| `root.css` | Concrete color hexes and dimension pixel values (the "Level 1" tokens). |
+| `light.css` | Light-theme mode tokens. Emitted at `:root` if you picked Light as default, otherwise wrapped in `.theme-light` / `[data-theme='light']` selectors. |
+| `dark.css` | Dark-theme mode tokens. Same default/wrapped behavior as `light.css`. |
+| `tw.css` | Tailwind v4 `@theme inline` config that re-exports every token for use with Tailwind utility classes. |
+
+### Using the bundle in your project
+
+1. Unzip the archive into your styles folder (e.g. `src/styles/`).
+2. Import the entry file once from your app's global stylesheet:
+   ```css
+   @import "./styles/index.css";
+   ```
+3. Switch themes at runtime by toggling a class on a wrapping element (or by setting `data-theme`):
+   ```html
+   <html class="theme-dark">  <!-- or class="theme-light" / data-theme="light" -->
+   ```
+   You only need this for the *non-default* theme — the default one is already applied at `:root`.
+
+## Inspect Variables (copy individual sections)
+
+For ad-hoc inspection or pulling a single section into an existing stylesheet, open the **Inspect variables** disclosure under the export button:
+
+1. Pick a **Mode** to resolve color aliases against.
+2. Click **Generate**. Four sections populate: Root, Mode, Component, and Other (fonts/blurs/shadows).
+3. Click **Copy** under any section to put that block on the clipboard.
 
 ## Development guide
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "change-case": "^5.4.4",
         "chroma-js": "^2.4.2",
         "copy-to-clipboard": "^3.3.3",
+        "jszip": "^3.10.1",
         "preact": "^10.22.0",
         "prismjs": "^1.28.0",
         "react-simple-code-editor": "^0.13.1"
@@ -1056,6 +1057,12 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1671,6 +1678,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/indent-string": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
@@ -1682,6 +1695,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1753,6 +1772,12 @@
       "integrity": "sha512-vIZ7HTXAoRoIwYSsTnxb0sg9L6rth+JOulNcavsbskQkCIWoSM2cjFOWZs4wGziGZER+Xgs/HXiCQZgiL8ppxQ==",
       "dev": true
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1782,6 +1807,18 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1790,6 +1827,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -2033,6 +2079,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/path-exists": {
       "version": "5.0.0",
@@ -2728,6 +2780,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2780,6 +2838,21 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -2874,6 +2947,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -2882,6 +2961,12 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2937,6 +3022,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-hash": {
@@ -3285,8 +3379,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "change-case": "^5.4.4",
     "chroma-js": "^2.4.2",
     "copy-to-clipboard": "^3.3.3",
+    "jszip": "^3.10.1",
     "preact": "^10.22.0",
     "prismjs": "^1.28.0",
     "react-simple-code-editor": "^0.13.1"

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -1,0 +1,333 @@
+type Token = { token: string; value: string };
+
+export type ExportPayload = {
+  fileName?: string;
+  rootColors: Token[];
+  rootDimensions: Token[];
+  modes: Record<string, Token[]>;
+  componentColors: Token[];
+  componentDimensions: Token[];
+  fontFamilies: Token[];
+  fontSizes: Token[];
+  lineHeights: Token[];
+  blurs: Token[];
+  shadows: Token[];
+};
+
+export function buildArchiveName(fileName?: string): string {
+  const fallback = 'styles';
+  if (!fileName) return `${fallback}.zip`;
+  const slug = fileName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug ? `${slug}-styles.zip` : `${fallback}.zip`;
+}
+
+const stripColorsSegment = (name: string) =>
+  name.replace(/^--color-colors-/, '--color-');
+
+const stripColorPrefix = (name: string) => name.replace(/^--color-/, '--');
+
+export const INDEX_CSS = `@import "./common.css";
+@import "./light.css";
+@import "./dark.css";
+@import "./root.css";
+@import "./tw.css";
+`;
+
+export const buildCommonCss = (defaultMode: DefaultMode) => `body {
+  color-scheme: ${defaultMode};
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+
+  @apply font-sans text-base;
+  line-height: 1.3;
+}
+
+blockquote,
+dd,
+dl,
+figure,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+p,
+pre {
+  margin: 0;
+}
+
+code {
+  @apply font-mono text-base;
+}
+
+body,
+#root {
+  margin: 0;
+  display: flex;
+  min-height: 100vh;
+  width: 100vw;
+
+  @apply bg-background-neutral-canvas-base text-content-text-on-color-light-dark;
+
+  --tooltip-background: var(--color-tooltip-colors-brand-background-default);
+  --color-on-tooltip: var(--color-white);
+  --tooltip-border-radius: 5px;
+  --tooltip-spacing: 5px;
+}
+`;
+
+// root.css: declares concrete root color hexes + root/component dimension pixel values.
+export function buildRootCss(data: ExportPayload): string {
+  const lines: string[] = [':root,', ':host {', '  /* Colors */'];
+  lines.push('  --color-white: #ffffff;');
+  lines.push('  --color-black: #000000;');
+  for (const { token, value } of data.rootColors) {
+    const name = stripColorsSegment(`--${token}`);
+    lines.push(`  ${name}: ${value};`);
+  }
+
+  lines.push('');
+  lines.push('  /* Dimensions */');
+  for (const { token, value } of data.rootDimensions) {
+    lines.push(`  --${token}: ${value};`);
+  }
+  for (const { token, value } of data.componentDimensions) {
+    lines.push(`  --${token}: ${value};`);
+  }
+
+  lines.push('}');
+  return lines.join('\n') + '\n';
+}
+
+function modeBody(tokens: Token[], indent: string): string[] {
+  return tokens.map(({ token, value }) => {
+    const name = stripColorPrefix(`--${token}`);
+    const ref = stripColorsSegment(`--${value}`);
+    return `${indent}${name}: var(${ref});`;
+  });
+}
+
+// Mode CSS emitted at :root for the default theme (no selector nesting needed).
+export function buildDefaultModeCss(slug: string, tokens: Token[]): string {
+  const lines: string[] = [':root,', ':host {', `  --reablocks-theme: ${slug};`, ''];
+  lines.push(...modeBody(tokens, '  '));
+  lines.push('}');
+  return lines.join('\n') + '\n';
+}
+
+// Mode CSS wrapped in `.theme-X` / `[data-theme=X]` selectors for non-default themes.
+export function buildWrappedModeCss(slug: string, tokens: Token[]): string {
+  const aliases =
+    slug === 'light' || slug === 'dark'
+      ? [
+          `  .theme-${slug},`,
+          `  &.theme-${slug},`,
+          `  .${slug},`,
+          `  &.${slug},`,
+          `  [data-theme='${slug}'],`,
+          `  &[data-theme='${slug}'] {`,
+        ]
+      : [
+          `  .theme-${slug},`,
+          `  &.theme-${slug},`,
+          `  [data-theme='${slug}'],`,
+          `  &[data-theme='${slug}'] {`,
+        ];
+  const lines: string[] = [
+    ':root,',
+    ':host {',
+    ...aliases,
+    `    --reablocks-theme: ${slug};`,
+    '',
+  ];
+  lines.push(...modeBody(tokens, '    '));
+  lines.push('  }');
+  lines.push('}');
+  return lines.join('\n') + '\n';
+}
+
+const RESET_COLORS = [
+  'red',
+  'pink',
+  'purple',
+  'orange',
+  'green',
+  'blue',
+  'gray',
+  'slate',
+  'teal',
+  'yellow',
+];
+
+// tw.css: Tailwind v4 theme config — re-exports tokens through @theme inline aliasing.
+export function buildTwCss(data: ExportPayload): string {
+  const lines: string[] = [];
+  lines.push(`@import 'tailwindcss';`);
+  lines.push(`@source "../../../node_modules/reablocks";`);
+  lines.push(`@source inline("line-clamp-{1..10}");`);
+  lines.push('');
+  lines.push(
+    `@custom-variant dark (&:where(.theme-dark, .theme-dark *, [data-theme=dark], [data-theme=dark] *));`
+  );
+  lines.push(
+    `@custom-variant light (&:where(.theme-light, .theme-light *, [data-theme=light], [data-theme=light] *));`
+  );
+  lines.push(
+    `@custom-variant disabled-within (&:has(input:is(:disabled), textarea:is(:disabled), button:is(:disabled)));`
+  );
+  lines.push('');
+  lines.push('@theme inline {');
+
+  if (data.fontFamilies.length) {
+    lines.push('  /* Fonts */');
+    for (const { token, value } of data.fontFamilies) {
+      lines.push(`  --${token}: ${value};`);
+    }
+    lines.push('');
+  }
+
+  lines.push('  /* Breakpoints */');
+  lines.push('  --breakpoint-3xl: 120rem;');
+  lines.push('');
+
+  if (data.fontSizes.length) {
+    lines.push('  /* Font Sizes */');
+    for (const { token, value } of data.fontSizes) {
+      lines.push(`  --${token}: ${value};`);
+    }
+    lines.push('');
+  }
+
+  if (data.lineHeights.length) {
+    lines.push('  /* Line Heights */');
+    for (const { token, value } of data.lineHeights) {
+      lines.push(`  --${token}: ${value};`);
+    }
+    lines.push('');
+  }
+
+  const corners = data.rootDimensions.filter((d) =>
+    d.token.startsWith('corner-radius-')
+  );
+  if (corners.length) {
+    lines.push('  /* Corner Radius */');
+    for (const { token } of corners) {
+      const radiusName = token.replace('corner-radius-', 'radius-');
+      lines.push(`  --${radiusName}: var(--${token});`);
+    }
+    lines.push('');
+  }
+
+  if (data.blurs.length) {
+    lines.push('  /* Blur */');
+    for (const { token, value } of data.blurs) {
+      lines.push(`  --${token}: ${value};`);
+    }
+    lines.push('');
+  }
+
+  if (data.shadows.length) {
+    lines.push('  /* Shadow */');
+    for (const { token, value } of data.shadows) {
+      lines.push(`  --${token}: ${value};`);
+    }
+    lines.push(
+      '  --shadow-brand-sm: 0 4px 4px 0 rgba(95, 97, 255, 0.3);',
+      '  --shadow-navigation-selected: 0 14px 20px 0 rgba(95, 97, 255, 0.3);',
+      '  --shadow-tooltip: 0 8px 12px 0 var(--effects-shadows-base-base);',
+      '  --shadow-grid-item: 0 2px 4px 0 rgba(26, 26, 26, 0.12);',
+      '  --shadow-menu: var(--drop-shadow-8) var(--drop-shadow-8) var(--blur-14) var(--drop-shadow-0) var(--gradient-brand-400);',
+      '  --shadow-backdrop: 0 8px 12px 0 var(--color-effects-shadows-base-base);'
+    );
+    lines.push('');
+  }
+
+  lines.push('  /* Reset defaults */');
+  for (const c of RESET_COLORS) {
+    lines.push(`  --color-${c}-*: initial;`);
+  }
+  lines.push('');
+
+  // Level 1: root colors → re-export with same name (used as @theme inline alias)
+  lines.push('  /* Color tokens Level 1 */');
+  for (const { token } of data.rootColors) {
+    const name = stripColorsSegment(`--${token}`);
+    lines.push(`  ${name}: var(${name});`);
+  }
+  lines.push('');
+
+  // Level 3: mode tokens → re-export `--color-X: var(--X)`
+  const firstMode = Object.values(data.modes)[0] ?? [];
+  if (firstMode.length) {
+    lines.push('  /* Color tokens Level 3 */');
+    for (const { token } of firstMode) {
+      const full = `--${token}`;
+      const stripped = stripColorPrefix(full);
+      lines.push(`  ${full}: var(${stripped});`);
+    }
+    lines.push('');
+  }
+
+  // Level 4: component color tokens → add `color-` prefix, strip color- from refs
+  if (data.componentColors.length) {
+    lines.push('  /* Component tokens Level 4 */');
+    for (const { token, value } of data.componentColors) {
+      const stripped = value.replace(/var\(--color-/g, 'var(--');
+      lines.push(`  --color-${token}: ${stripped};`);
+    }
+  }
+
+  lines.push('}');
+  return lines.join('\n') + '\n';
+}
+
+export type DefaultMode = 'light' | 'dark';
+
+export function buildAllFiles(
+  data: ExportPayload,
+  defaultMode: DefaultMode = 'dark'
+): Record<string, string> {
+  const files: Record<string, string> = {
+    'index.css': INDEX_CSS,
+    'common.css': buildCommonCss(defaultMode),
+    'root.css': buildRootCss(data),
+    'tw.css': buildTwCss(data),
+  };
+
+  const entries = Object.entries(data.modes);
+  let lightEntry = entries.find(([n]) => /\blight\b/i.test(n));
+  let darkEntry = entries.find(([n]) => /\bdark\b/i.test(n));
+
+  // Fall back to substring match if word-boundary didn't catch a mode name.
+  if (!lightEntry) lightEntry = entries.find(([n]) => n.toLowerCase().includes('light'));
+  if (!darkEntry) darkEntry = entries.find(([n]) => n.toLowerCase().includes('dark'));
+
+  if (lightEntry) {
+    const builder = defaultMode === 'light' ? buildDefaultModeCss : buildWrappedModeCss;
+    files['light.css'] = builder('light', lightEntry[1]);
+  }
+  if (darkEntry) {
+    const builder = defaultMode === 'dark' ? buildDefaultModeCss : buildWrappedModeCss;
+    files['dark.css'] = builder('dark', darkEntry[1]);
+  }
+
+  for (const [modeName, tokens] of entries) {
+    if (modeName === lightEntry?.[0] || modeName === darkEntry?.[0]) continue;
+    const slug = modeName.toLowerCase().replace(/\s+/g, '-');
+    files[`${slug}.css`] = buildWrappedModeCss(slug, tokens);
+  }
+
+  if (!lightEntry) files['light.css'] = '/* No "Light" mode found in Figma variables. */\n';
+  if (!darkEntry) files['dark.css'] = '/* No "Dark" mode found in Figma variables. */\n';
+
+  return files;
+}

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -305,11 +305,21 @@ export function buildAllFiles(
 
   const entries = Object.entries(data.modes);
   let lightEntry = entries.find(([n]) => /\blight\b/i.test(n));
-  let darkEntry = entries.find(([n]) => /\bdark\b/i.test(n));
+  let darkEntry = entries.find(([n]) => /\bdark\b/i.test(n) && n !== lightEntry?.[0]);
 
   // Fall back to substring match if word-boundary didn't catch a mode name.
-  if (!lightEntry) lightEntry = entries.find(([n]) => n.toLowerCase().includes('light'));
-  if (!darkEntry) darkEntry = entries.find(([n]) => n.toLowerCase().includes('dark'));
+  // Exclude the other slot's entry so an ambiguous name (e.g. "Light Dark Hybrid"
+  // or "darklight") can't be emitted as both light.css and dark.css.
+  if (!lightEntry) {
+    lightEntry = entries.find(
+      ([n]) => n.toLowerCase().includes('light') && n !== darkEntry?.[0]
+    );
+  }
+  if (!darkEntry) {
+    darkEntry = entries.find(
+      ([n]) => n.toLowerCase().includes('dark') && n !== lightEntry?.[0]
+    );
+  }
 
   if (lightEntry) {
     const builder = defaultMode === 'light' ? buildDefaultModeCss : buildWrappedModeCss;

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,301 +19,342 @@ const DIMENSIONS_VARIABLES = [
   'Corner Radius',
 ];
 
-export default function () {
-  const getNestedVariable = async (id: string, collectionName: string, mode?: string): Promise<Variable | null> => {
-    const variable = await figma.variables.getVariableByIdAsync(id);
-    const collection = await figma.variables.getVariableCollectionByIdAsync(variable?.variableCollectionId as string);
-    const firstValueMode = Object.keys(variable?.valuesByMode ?? [])?.[0];
+type Token = { token: string; value: string };
 
-    if (collection?.name === collectionName) {
-      return variable;
-    } else {
-      const value = (variable?.valuesByMode[mode || firstValueMode] as VariableAlias)?.id;
-      return value ? getNestedVariable(value, collectionName) : null;
+function isAlias(value: VariableValue | undefined): value is VariableAlias {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (value as VariableAlias).type === 'VARIABLE_ALIAS'
+  );
+}
+
+function isRgba(value: VariableValue | undefined): value is RGBA {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'r' in value &&
+    'g' in value &&
+    'b' in value
+  );
+}
+
+export default function () {
+  const collections: Map<string, VariableCollection> = new Map();
+
+  async function loadCollections() {
+    const all = await figma.variables.getLocalVariableCollectionsAsync();
+    collections.clear();
+    for (const c of all) collections.set(c.name, c);
+    return collections;
+  }
+
+  // Resolve aliases through the user-selected style mode when traversing the Style collection,
+  // otherwise fall back to the collection's defaultModeId (the "Auto" target in Figma).
+  async function resolveAlias(
+    id: string,
+    targetCollectionName: string,
+    styleMode?: string
+  ): Promise<Variable | null> {
+    const variable = await figma.variables.getVariableByIdAsync(id);
+    if (!variable) return null;
+    const collection = await figma.variables.getVariableCollectionByIdAsync(
+      variable.variableCollectionId
+    );
+    if (collection?.name === targetCollectionName) return variable;
+
+    const fallbackMode =
+      collection?.defaultModeId ?? Object.keys(variable.valuesByMode)[0];
+    const resolveMode =
+      collection?.name === STYLE_COLLECTION_NAME && styleMode
+        ? styleMode
+        : fallbackMode;
+
+    const next = variable.valuesByMode[resolveMode];
+    return isAlias(next) ? resolveAlias(next.id, targetCollectionName, styleMode) : null;
+  }
+
+  async function collectRootColors(): Promise<Token[]> {
+    const tokens: Token[] = [];
+    const coll = collections.get(ROOT_COLLECTION_NAME);
+    const mode = coll?.defaultModeId;
+    if (!coll || !mode) return tokens;
+    for (const id of coll.variableIds) {
+      const variable = await figma.variables.getVariableByIdAsync(id);
+      if (variable?.resolvedType !== 'COLOR') continue;
+      const value = variable.valuesByMode[mode];
+      if (!isRgba(value)) continue;
+      const { r, g, b, a } = value;
+      const hex = chroma
+        .rgb(r * 255, g * 255, b * 255)
+        .alpha(a ?? 1)
+        .hex();
+      tokens.push({ token: kebabCase(variable.name), value: hex });
     }
+    return tokens;
+  }
+
+  async function collectRootDimensions(): Promise<Token[]> {
+    const tokens: Token[] = [];
+    const coll = collections.get(DIMENSIONS_COLLECTION_NAME);
+    const mode = coll?.defaultModeId;
+    if (!coll || !mode) return tokens;
+    for (const id of coll.variableIds) {
+      const variable = await figma.variables.getVariableByIdAsync(id);
+      const group = DIMENSIONS_VARIABLES.find((v) =>
+        variable?.name?.startsWith(v)
+      );
+      if (!variable || !group) continue;
+      const leaf = variable.name.split('/').pop()?.toLowerCase() ?? '';
+      const value = variable.valuesByMode[mode];
+      if (!isAlias(value)) continue;
+      const target = await resolveAlias(value.id, ROOT_COLLECTION_NAME);
+      const firstMode = Object.keys(target?.valuesByMode ?? {})[0];
+      const px = target?.valuesByMode?.[firstMode];
+      if (typeof px !== 'number') continue;
+      tokens.push({
+        token: `${kebabCase(group)}-${kebabCase(leaf)}`,
+        value: `${px}px`,
+      });
+    }
+    return tokens;
+  }
+
+  async function collectModeTokens(modeId: string): Promise<Token[]> {
+    const tokens: Token[] = [];
+    const coll = collections.get(MODE_COLLECTION_NAME);
+    if (!coll) return tokens;
+    for (const id of coll.variableIds) {
+      const variable = await figma.variables.getVariableByIdAsync(id);
+      if (variable?.resolvedType !== 'COLOR') continue;
+      const value = variable.valuesByMode[modeId];
+      if (!isAlias(value)) continue;
+      const target = await resolveAlias(value.id, ROOT_COLLECTION_NAME);
+      tokens.push({
+        token: kebabCase(variable.name),
+        value: kebabCase(target?.name ?? ''),
+      });
+    }
+    return tokens;
+  }
+
+  async function collectComponentTokens(): Promise<{
+    colors: Token[];
+    dimensions: Token[];
+  }> {
+    const colors: Token[] = [];
+    const dimensions: Token[] = [];
+    const coll = collections.get(COMPONENTS_COLLECTION_NAME);
+    const mode = coll?.defaultModeId;
+    if (!coll || !mode) return { colors, dimensions };
+
+    const dimensionScopes: VariableScope[] = ['GAP', 'WIDTH_HEIGHT', 'CORNER_RADIUS'];
+
+    for (const id of coll.variableIds) {
+      const variable = await figma.variables.getVariableByIdAsync(id);
+      if (!variable) continue;
+      const value = variable.valuesByMode[mode];
+      if (!isAlias(value)) continue;
+
+      if (variable.resolvedType === 'COLOR') {
+        const target = await resolveAlias(value.id, MODE_COLLECTION_NAME);
+        colors.push({
+          token: kebabCase(variable.name),
+          value: `var(--${kebabCase(target?.name?.toLowerCase() ?? '')})`,
+        });
+      } else if (
+        Array.isArray(variable.scopes) &&
+        dimensionScopes.some((s) => variable.scopes.includes(s))
+      ) {
+        let tokenValue = '';
+        const dimensionVariable = await resolveAlias(
+          value.id,
+          DIMENSIONS_COLLECTION_NAME
+        );
+        if (!dimensionVariable) {
+          const target = await resolveAlias(value.id, ROOT_COLLECTION_NAME);
+          const firstMode = Object.keys(target?.valuesByMode ?? {})[0];
+          const px = target?.valuesByMode?.[firstMode];
+          if (typeof px !== 'number') continue;
+          tokenValue = `${px}px`;
+        } else {
+          tokenValue = `var(--${kebabCase(dimensionVariable.name.toLowerCase())})`;
+        }
+        dimensions.push({ token: kebabCase(variable.name), value: tokenValue });
+      }
+    }
+    return { colors, dimensions };
+  }
+
+  async function collectTypography(stylesMode?: string): Promise<{
+    fontFamilies: Token[];
+    fontSizes: Token[];
+    lineHeights: Token[];
+    blurs: Token[];
+    shadows: Token[];
+  }> {
+    const fontFamilies: Token[] = [];
+    const fontSizes: Token[] = [];
+    const lineHeights: Token[] = [];
+    const blurs: Token[] = [];
+    const shadows: Token[] = [];
+
+    const rootColl = collections.get(ROOT_COLLECTION_NAME);
+    const stylesColl = collections.get(STYLE_COLLECTION_NAME);
+    const rootMode = rootColl?.defaultModeId;
+    const resolvedStylesMode = stylesMode ?? stylesColl?.defaultModeId;
+
+    if (rootColl && rootMode) {
+      let fontsStoredCount = 0;
+      for (const id of rootColl.variableIds) {
+        const variable = await figma.variables.getVariableByIdAsync(id);
+        if (!variable) continue;
+        const value = variable.valuesByMode[rootMode];
+
+        if (variable.name.startsWith('Typography/Family')) {
+          if (typeof value !== 'string') continue;
+          if (variable.name.toLowerCase().includes('mono')) {
+            fontFamilies.push({ token: 'font-mono', value: `"${value}", monospace` });
+          } else if (fontsStoredCount === 0) {
+            fontFamilies.push({ token: 'font-sans', value: `"${value}", sans-serif` });
+          } else if (fontsStoredCount === 1) {
+            fontFamilies.push({ token: 'font-serif', value: `"${value}", serif` });
+          }
+          fontsStoredCount++;
+        } else if (variable.name.startsWith('Effects/Blur')) {
+          const leaf = variable.name.split('/').pop()?.toLowerCase() ?? '';
+          if (typeof value !== 'number') continue;
+          blurs.push({ token: `blur-${leaf}`, value: `${value / 16}rem` });
+        } else if (variable.name.startsWith('Effects/Shadow')) {
+          const leaf = variable.name.split('/').pop()?.toLowerCase() ?? '';
+          if (typeof value !== 'number') continue;
+          shadows.push({ token: `drop-shadow-${leaf}`, value: `${value / 16}rem` });
+        }
+      }
+    }
+
+    if (stylesColl && resolvedStylesMode && rootMode) {
+      for (const id of stylesColl.variableIds) {
+        const variable = await figma.variables.getVariableByIdAsync(id);
+        if (!variable) continue;
+        const value = variable.valuesByMode[resolvedStylesMode];
+        if (!isAlias(value)) continue;
+
+        if (variable.name.startsWith('Typography/Font Size')) {
+          const leaf = variable.name.split('/').pop()?.toLowerCase() ?? '';
+          const target = await resolveAlias(value.id, ROOT_COLLECTION_NAME, resolvedStylesMode);
+          const px = target?.valuesByMode?.[rootMode];
+          if (typeof px !== 'number') continue;
+          fontSizes.push({ token: `text-${leaf}`, value: `${px / 16}rem` });
+        } else if (variable.name.startsWith('Typography/Line Height')) {
+          const leaf = variable.name.split('/').pop()?.toLowerCase() ?? '';
+          const target = await resolveAlias(value.id, ROOT_COLLECTION_NAME, resolvedStylesMode);
+          const px = target?.valuesByMode?.[rootMode];
+          if (typeof px !== 'number') continue;
+          lineHeights.push({ token: `text-${leaf}--line-height`, value: `${px / 16}rem` });
+        }
+      }
+    }
+
+    return { fontFamilies, fontSizes, lineHeights, blurs, shadows };
   }
 
   on('LOAD_MODES', async () => {
-    const collections = await figma.variables.getLocalVariableCollectionsAsync();
-    const modes = collections.reduce((cur, col) => {
-      if (col.name !== MODE_COLLECTION_NAME) {
-        return cur;
-      }
+    await loadCollections();
+    const modeColl = collections.get(MODE_COLLECTION_NAME);
+    const styleColl = collections.get(STYLE_COLLECTION_NAME);
 
-      for (const mode of col.modes) {
-        cur = {...cur, [mode.modeId]: mode.name};
-      }
-      return cur;
-    }, {} as Record<string, string>);
+    const modes: Record<string, string> = {};
+    for (const m of modeColl?.modes ?? []) modes[m.modeId] = m.name;
 
-    emit('LOADED_MODES', { modes });
+    const styleModes: Record<string, string> = {};
+    for (const m of styleColl?.modes ?? []) styleModes[m.modeId] = m.name;
+
+    emit('LOADED_MODES', {
+      modes,
+      defaultModeId: modeColl?.defaultModeId,
+      styleModes,
+      defaultStyleModeId: styleColl?.defaultModeId,
+    });
   });
 
   on('GENERATE_ROOT_VARIABLES', async () => {
-    const tokens = [];
-    const collections = await figma.variables.getLocalVariableCollectionsAsync();
-    const colorsCollection = collections.filter(({ name }) => name === ROOT_COLLECTION_NAME)?.[0];
-    const dimensionsCollection = collections.filter(({ name }) => name === DIMENSIONS_COLLECTION_NAME)?.[0];
-    const mode = colorsCollection?.modes?.[0]?.modeId; // Only one mode is supported for Root level
-    const dimensionsMode = dimensionsCollection?.modes?.[0]?.modeId; // Get the first mode as default
-
-    tokens.push('/* Colors */');
-    for (const variableId of colorsCollection?.variableIds || []) {
-      const variable = await figma.variables.getVariableByIdAsync(variableId);
-
-      // Only colors need to be exported
-      if (variable?.resolvedType === 'COLOR') {
-        const name = kebabCase(variable?.name);
-        const value = variable?.valuesByMode[mode];
-        const { r, g, b, a } = value as any;
-        const hex = chroma
-          .rgb(r * 255, g * 255, b * 255)
-          .alpha(a ?? 1)
-          .hex();
-
-        tokens.push({
-          token: name,
-          value: hex,
-        });
-      }
-    }
-
-    tokens.push('');
-    tokens.push('/* Dimensions */');
-    for (const variableId of dimensionsCollection?.variableIds || []) {
-      const variable = await figma.variables.getVariableByIdAsync(variableId);
-      const dimensionVariable = DIMENSIONS_VARIABLES.find((v) =>
-        variable?.name?.startsWith(v)
-      );
-
-      if (dimensionVariable) {
-        const name = variable?.name.split('/')?.pop()?.toLowerCase();
-        const value = variable?.valuesByMode?.[dimensionsMode];
-
-        if ((value as VariableAlias)?.type === 'VARIABLE_ALIAS') {
-          const targetVariable = await getNestedVariable(
-            (value as VariableAlias)?.id,
-            ROOT_COLLECTION_NAME
-          );
-          const firstValueMode = Object.keys(
-            targetVariable?.valuesByMode ?? {}
-          )[0];
-          const padding = targetVariable?.valuesByMode?.[
-            firstValueMode
-          ] as number;
-          tokens.push({
-            token: `${kebabCase(dimensionVariable)}-${kebabCase(name ?? '')}`,
-            value: `${padding}px`,
-          });
-        }
-      }
-    }
+    await loadCollections();
+    const colors = await collectRootColors();
+    const dimensions = await collectRootDimensions();
+    const tokens: (string | Token)[] = ['/* Colors */', ...colors, '', '/* Dimensions */', ...dimensions];
     emit('GENERATED_ROOT_VARIABLES', { tokens });
   });
 
-  on('GENERATE_MODE_VARIABLES', async ({ mode }) => {
-    const tokens = [];
-    const collections = await figma.variables.getLocalVariableCollectionsAsync();
-    const modesCollection = collections.filter(({ name }) => name === MODE_COLLECTION_NAME)?.[0];
-
-    for (const variableId of modesCollection?.variableIds || []) {
-      const variable = await figma.variables.getVariableByIdAsync(variableId);
-
-      // Only colors need to be exported
-      if (variable?.resolvedType === 'COLOR') {
-        const name = kebabCase(variable?.name);
-        const value = variable.valuesByMode[mode]
-
-        if ((value as VariableAlias)?.type === 'VARIABLE_ALIAS') {
-          const targetVariable = await getNestedVariable((value as VariableAlias)?.id, ROOT_COLLECTION_NAME);
-
-          tokens.push({
-            token: name,
-            value: kebabCase(targetVariable?.name ?? ''),
-          })
-        }
-      }
-    }
-
+  on('GENERATE_MODE_VARIABLES', async ({ mode }: { mode: string }) => {
+    await loadCollections();
+    const tokens = await collectModeTokens(mode);
     emit('GENERATED_MODE_VARIABLES', { tokens });
   });
 
   on('GENERATE_COMPONENT_VARIABLES', async () => {
-    const colorTokens = [];
-    const dimensionTokens = [];
-    const collections = await figma.variables.getLocalVariableCollectionsAsync();
-    const modesCollection = collections.filter(({ name }) => name === COMPONENTS_COLLECTION_NAME)?.[0];
-    const mode = modesCollection?.modes?.[0]?.modeId;
-
-    for (const variableId of modesCollection?.variableIds || []) {
-      const variable = await figma.variables.getVariableByIdAsync(variableId);
-
-      // Only colors need to be exported
-      if (variable?.resolvedType === 'COLOR') {
-        const name = kebabCase(variable?.name);
-        const value = variable.valuesByMode[mode]
-
-        if ((value as VariableAlias)?.type === 'VARIABLE_ALIAS') {
-          const targetVariable = await getNestedVariable((value as VariableAlias)?.id, MODE_COLLECTION_NAME);
-
-          colorTokens.push({
-            token: name,
-            value: `var(--${kebabCase(targetVariable?.name?.toLowerCase() ?? '')})`,
-          })
-        }
-      } else if (
-        Array.isArray(variable?.scopes) &&
-        ['GAP', 'WIDTH_HEIGHT', 'CORNER_RADIUS'].some((scope) => variable.scopes.includes(scope as VariableScope))
-      ) {
-        const name = kebabCase(variable?.name);
-        const value = variable.valuesByMode[mode];
-        
-        if ((value as VariableAlias)?.type === 'VARIABLE_ALIAS') {
-          let tokenValue = '';
-          const dimensionVariable = await getNestedVariable((value as VariableAlias)?.id, DIMENSIONS_COLLECTION_NAME);
-          if (!dimensionVariable) {
-            const targetVariable = await getNestedVariable(
-              (value as VariableAlias)?.id,
-              ROOT_COLLECTION_NAME
-            );
-            const firstValueMode = Object.keys(targetVariable?.valuesByMode ?? {})?.[0];
-            tokenValue = `${targetVariable?.valuesByMode?.[firstValueMode]}px`;
-          } else {
-            const name = dimensionVariable?.name?.toLowerCase() ?? ''
-            tokenValue = `var(--${kebabCase(name)})`
-          }
-  
-          dimensionTokens.push({
-            token: kebabCase(name ?? ''),
-            value: tokenValue,
-          })
-        }
-      }
-    }
-
-    const tokens: (string | { token: string; value: string })[] = [];
-    if (colorTokens.length > 0) {
-      tokens.push("/* Color Tokens */");
-      tokens.push(...colorTokens);
-    }
-    if (dimensionTokens.length > 0) {
-      tokens.push('');
-      tokens.push("/* Dimension Tokens */");
-      tokens.push(...dimensionTokens);
-    }
-
+    await loadCollections();
+    const { colors, dimensions } = await collectComponentTokens();
+    const tokens: (string | Token)[] = [];
+    if (colors.length) tokens.push('/* Color Tokens */', ...colors);
+    if (dimensions.length) tokens.push('', '/* Dimension Tokens */', ...dimensions);
     emit('GENERATED_COMPONENT_VARIABLES', { tokens });
   });
 
-  on('GENERATE_OTHER_VARIABLES', async () => {
-    const tokens = [];
-    const collections = await figma.variables.getLocalVariableCollectionsAsync();
-    const stylesCollection = collections.filter(({ name }) => name === STYLE_COLLECTION_NAME)?.[0];
-    const rootCollection = collections.filter(({ name }) => name === ROOT_COLLECTION_NAME)?.[0];
-    const rootMode = rootCollection?.modes?.[0]?.modeId; // Only one mode is supported for Root level
-    const stylesMode = stylesCollection?.modes?.[0]?.modeId; // Only one mode is supported for Root level
-
-    let fontsStoredCount = 0;
-
-    tokens.push('/* Font Families */');
-    for (const variableId of rootCollection?.variableIds || []) {
-      const variable = await figma.variables.getVariableByIdAsync(variableId);
-
-      if (variable?.name?.startsWith('Typography/Family')) {
-        if (variable?.name?.toLowerCase()?.includes('mono')) {
-          tokens.push({
-            token: 'font-mono',
-            value: `"${variable?.valuesByMode[rootMode]}", monospace`
-          })
-        } else if (fontsStoredCount === 0) {
-          tokens.push({
-            token: 'font-sans',
-            value: `"${variable?.valuesByMode[rootMode]}", sans-serif`
-          });
-        } else if (fontsStoredCount === 1) {
-          tokens.push({
-            token: 'font-serif',
-            value: `"${variable?.valuesByMode[rootMode]}", serif`
-          });
-        }
-        fontsStoredCount++;
-      }
-    }
-
-    tokens.push('');
-    tokens.push('/* Font Sizes */');
-    for (const variableId of stylesCollection?.variableIds || []) {
-      const variable = await figma.variables.getVariableByIdAsync(variableId);
-
-      if (variable?.name?.startsWith('Typography/Font Size')) {
-        const name = variable?.name.split('/')?.pop()?.toLowerCase();
-        const value = variable.valuesByMode[stylesMode]
-
-        if ((value as VariableAlias)?.type === 'VARIABLE_ALIAS') {
-          const targetVariable = await getNestedVariable((value as VariableAlias)?.id, ROOT_COLLECTION_NAME);
-          const fontSize = targetVariable?.valuesByMode?.[rootMode] as number;
-          tokens.push({
-            token: `text-${name}`,
-            value: `${fontSize / 16}rem`,
-          })
-        }
-      }
-    }
-
-    tokens.push('');
-    tokens.push('/* Line Heights */');
-    for (const variableId of stylesCollection?.variableIds || []) {
-      const variable = await figma.variables.getVariableByIdAsync(variableId);
-
-      if (variable?.name?.startsWith('Typography/Line Height')) {
-        const name = variable?.name.split('/')?.pop()?.toLowerCase();
-        const value = variable.valuesByMode[stylesMode]
-
-        if ((value as VariableAlias)?.type === 'VARIABLE_ALIAS') {
-          const targetVariable = await getNestedVariable((value as VariableAlias)?.id, ROOT_COLLECTION_NAME);
-          const fontSize = targetVariable?.valuesByMode?.[rootMode] as number;
-          tokens.push({
-            token: `text-${name}--line-height`,
-            value: `${fontSize / 16}rem`,
-          })
-        }
-      }
-    }
-
-    tokens.push('');
-    tokens.push('/* Blur */');
-    for (const variableId of rootCollection?.variableIds || []) {
-      const variable = await figma.variables.getVariableByIdAsync(variableId);
-
-      if (variable?.name?.startsWith('Effects/Blur')) {
-        const name = variable?.name.split('/')?.pop()?.toLowerCase();
-        const value = variable.valuesByMode[rootMode] as number;
-
-        tokens.push({
-          token: `blur-${name}`,
-          value: `${value / 16}rem`,
-        })
-      }
-    }
-
-    tokens.push('');
-    tokens.push('/* Shadow */');
-    for (const variableId of rootCollection?.variableIds || []) {
-      const variable = await figma.variables.getVariableByIdAsync(variableId);
-
-      if (variable?.name?.startsWith('Effects/Shadow')) {
-        const name = variable?.name.split('/')?.pop()?.toLowerCase();
-        const value = variable.valuesByMode[rootMode] as number;
-
-        tokens.push({
-          token: `drop-shadow-${name}`,
-          value: `${value / 16}rem`,
-        })
-      }
-    }
-
+  on('GENERATE_OTHER_VARIABLES', async ({ styleMode }: { styleMode?: string } = {}) => {
+    await loadCollections();
+    const { fontFamilies, fontSizes, lineHeights, blurs, shadows } =
+      await collectTypography(styleMode);
+    const tokens: (string | Token)[] = [
+      '/* Font Families */',
+      ...fontFamilies,
+      '',
+      '/* Font Sizes */',
+      ...fontSizes,
+      '',
+      '/* Line Heights */',
+      ...lineHeights,
+      '',
+      '/* Blur */',
+      ...blurs,
+      '',
+      '/* Shadow */',
+      ...shadows,
+    ];
     emit('GENERATED_OTHER_VARIABLES', { tokens });
   });
 
-  showUI({ height: 500, width: 400 });
+  on('EXPORT_ALL', async ({ styleMode }: { styleMode?: string } = {}) => {
+    await loadCollections();
+    const modesColl = collections.get(MODE_COLLECTION_NAME);
+
+    const rootColors = await collectRootColors();
+    const rootDimensions = await collectRootDimensions();
+
+    const modes: Record<string, Token[]> = {};
+    for (const m of modesColl?.modes ?? []) {
+      modes[m.name] = await collectModeTokens(m.modeId);
+    }
+
+    const { colors: componentColors, dimensions: componentDimensions } =
+      await collectComponentTokens();
+    const { fontFamilies, fontSizes, lineHeights, blurs, shadows } =
+      await collectTypography(styleMode);
+
+    emit('EXPORTED_ALL', {
+      fileName: figma.root.name,
+      rootColors,
+      rootDimensions,
+      modes,
+      componentColors,
+      componentDimensions,
+      fontFamilies,
+      fontSizes,
+      lineHeights,
+      blurs,
+      shadows,
+    });
+  });
+
+  showUI({ height: 540, width: 400 });
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,3 +2,11 @@
   overflow: auto;
   border: 1px solid #ffffff1A;
 }
+
+.loading {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/styles.css.d.ts
+++ b/src/styles.css.d.ts
@@ -1,5 +1,6 @@
 declare const styles: {
   readonly "container": string;
+  readonly "loading": string;
 };
 export = styles;
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -70,6 +70,7 @@ function Plugin() {
 
   const copyTimers = useRef<Record<string, number>>({});
   const exportInFlight = useRef(false);
+  const exportUnsubscribe = useRef<(() => void) | null>(null);
 
   /**
    * Schedules a deferred state reset (used to revert button labels like
@@ -159,6 +160,10 @@ function Plugin() {
     let timeoutId: number | undefined;
     const finish = (text: string) => {
       if (timeoutId) clearTimeout(timeoutId);
+      if (exportUnsubscribe.current) {
+        exportUnsubscribe.current();
+        exportUnsubscribe.current = null;
+      }
       exportInFlight.current = false;
       setExportButtonText(text);
       if (text !== EXPORT_TITLE) {
@@ -171,7 +176,7 @@ function Plugin() {
       finish(EXPORT_TITLE);
     }, EXPORT_TIMEOUT_MS);
 
-    once('EXPORTED_ALL', async (payload: ExportPayload) => {
+    exportUnsubscribe.current = once('EXPORTED_ALL', async (payload: ExportPayload) => {
       try {
         const files = buildAllFiles(payload, rootTheme);
         const zip = new JSZip();
@@ -283,6 +288,10 @@ function Plugin() {
       offMode();
       offComponent();
       offOther();
+      if (exportUnsubscribe.current) {
+        exportUnsubscribe.current();
+        exportUnsubscribe.current = null;
+      }
       for (const id of Object.values(timers)) clearTimeout(id);
     };
   }, []);

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -3,6 +3,7 @@ import '!prismjs/themes/prism.css';
 import {
   Button,
   Container,
+  Disclosure,
   Dropdown,
   render,
   TextboxMultiline,
@@ -10,14 +11,45 @@ import {
 } from '@create-figma-plugin/ui';
 import { emit, on, once } from '@create-figma-plugin/utilities';
 import copy from 'copy-to-clipboard';
-import { h } from 'preact';
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import JSZip from 'jszip';
+import { Fragment, h } from 'preact';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import { buildAllFiles, buildArchiveName, DefaultMode, ExportPayload } from './exporter';
 import styles from './styles.css';
 
 const GENERATING_TITLE = 'Generating...';
 const COPIED_TITLE = 'Copied!';
 const COPY_TITLE = 'Copy';
+const EXPORT_TITLE = 'Export Styles';
+const EXPORT_GENERATING_TITLE = 'Building zip...';
+const EXPORT_DONE_TITLE = 'Downloaded!';
+const EXPORT_TIMEOUT_MS = 30_000;
 
+type Token = { token: string; value: string };
+
+/**
+ * Renders a mixed list of section headers and `{ token, value }` pairs
+ * into a single CSS-variable text block. Strings are passed through verbatim
+ * (used for `/* Colors *​/` style separators) while token objects become
+ * `--token: value;` lines.
+ */
+function formatTokens(tokens: (string | Token)[]): string {
+  return tokens
+    .map((val) => (typeof val === 'string' ? val : `--${val.token}: ${val.value};`))
+    .join('\n');
+}
+
+/**
+ * Root component for the plugin UI.
+ *
+ * Talks to `main.ts` over the @create-figma-plugin message bus:
+ *  - emits `LOAD_MODES`, `GENERATE_*`, and `EXPORT_ALL`
+ *  - listens for `LOADED_MODES`, `GENERATED_*`, and `EXPORTED_ALL`
+ *
+ * Renders one of three states: loading, "no Unify variables found", or
+ * the main controls (theme picker, export button, and an inspector
+ * disclosure with per-section copy buttons).
+ */
 function Plugin() {
   const [modesLoading, setModesLoading] = useState<boolean>(true);
   const [colorVariables, setColorVariables] = useState('');
@@ -26,13 +58,46 @@ function Plugin() {
   const [otherVariables, setOtherVariables] = useState('');
   const [modes, setModes] = useState<Record<string, string>>({});
   const [selectedMode, setSelectedMode] = useState<string | null>(null);
+  const [styleModes, setStyleModes] = useState<Record<string, string>>({});
+  const [selectedStyleMode, setSelectedStyleMode] = useState<string | null>(null);
   const [colorsCopyButtonText, setColorsCopyButtonText] = useState(COPY_TITLE);
   const [modeCopyButtonText, setModeCopyButtonText] = useState(COPY_TITLE);
-  const [componentCopyButtonText, setComponentCopyButtonText] =
-    useState(COPY_TITLE);
-  const [otherCopyButtonText, setOtherCopyButtonText] =
-    useState(COPY_TITLE);
+  const [componentCopyButtonText, setComponentCopyButtonText] = useState(COPY_TITLE);
+  const [otherCopyButtonText, setOtherCopyButtonText] = useState(COPY_TITLE);
+  const [exportButtonText, setExportButtonText] = useState(EXPORT_TITLE);
+  const [rootTheme, setRootTheme] = useState<DefaultMode>('dark');
+  const [inspectOpen, setInspectOpen] = useState(false);
 
+  const copyTimers = useRef<Record<string, number>>({});
+  const exportInFlight = useRef(false);
+
+  /**
+   * Schedules a deferred state reset (used to revert button labels like
+   * "Copied!" back to "Copy" after 2 seconds). Any previously scheduled
+   * reset under the same `key` is cancelled first, so rapid clicks don't
+   * race or leave the label stuck on the wrong state.
+   *
+   * @param key   Identifier for the timer slot (e.g. `'colors'`, `'export'`).
+   * @param reset Callback invoked after the delay to revert state.
+   */
+  const scheduleReset = useCallback(
+    (key: string, reset: () => void) => {
+      const prev = copyTimers.current[key];
+      if (prev) clearTimeout(prev);
+      copyTimers.current[key] = window.setTimeout(() => {
+        reset();
+        delete copyTimers.current[key];
+      }, 2000);
+    },
+    []
+  );
+
+  /**
+   * Triggers regeneration of all four inspector token sections (root, mode,
+   * component, other) by emitting the matching `GENERATE_*` events to
+   * `main.ts`. Each text area is set to "Generating..." until its
+   * corresponding `GENERATED_*` response arrives.
+   */
   const generateVariablesHandler = useCallback(() => {
     setColorVariables(GENERATING_TITLE);
     setModeVariables(GENERATING_TITLE);
@@ -41,106 +106,193 @@ function Plugin() {
     emit('GENERATE_ROOT_VARIABLES');
     emit('GENERATE_MODE_VARIABLES', { mode: selectedMode });
     emit('GENERATE_COMPONENT_VARIABLES');
-    emit('GENERATE_OTHER_VARIABLES');
-  }, [selectedMode]);
+    emit('GENERATE_OTHER_VARIABLES', { styleMode: selectedStyleMode });
+  }, [selectedMode, selectedStyleMode]);
 
+  /** Copies the root-variables text block to the clipboard and flashes "Copied!" for 2s. */
   const copyColors = useCallback(() => {
     copy(colorVariables);
     setColorsCopyButtonText(COPIED_TITLE);
-    setTimeout(() => setColorsCopyButtonText(COPY_TITLE), 2000);
-  }, [colorVariables]);
+    scheduleReset('colors', () => setColorsCopyButtonText(COPY_TITLE));
+  }, [colorVariables, scheduleReset]);
 
+  /** Copies the mode-tokens text block to the clipboard and flashes "Copied!" for 2s. */
   const copyModeTokens = useCallback(() => {
     copy(modeVariables);
     setModeCopyButtonText(COPIED_TITLE);
-    setTimeout(() => setModeCopyButtonText(COPY_TITLE), 2000);
-  }, [modeVariables]);
+    scheduleReset('mode', () => setModeCopyButtonText(COPY_TITLE));
+  }, [modeVariables, scheduleReset]);
 
+  /** Copies the component-tokens text block to the clipboard and flashes "Copied!" for 2s. */
   const copyTokens = useCallback(() => {
     copy(componentVariables);
     setComponentCopyButtonText(COPIED_TITLE);
-    setTimeout(() => setComponentCopyButtonText(COPY_TITLE), 2000);
-  }, [componentVariables]);
+    scheduleReset('component', () => setComponentCopyButtonText(COPY_TITLE));
+  }, [componentVariables, scheduleReset]);
 
+  /** Copies the "other" tokens text block (fonts, blurs, shadows) to the clipboard and flashes "Copied!" for 2s. */
   const copyOther = useCallback(() => {
     copy(otherVariables);
     setOtherCopyButtonText(COPIED_TITLE);
-    setTimeout(() => setOtherCopyButtonText(COPY_TITLE), 2000);
-  }, [otherVariables]);
+    scheduleReset('other', () => setOtherCopyButtonText(COPY_TITLE));
+  }, [otherVariables, scheduleReset]);
+
+  /**
+   * Kicks off a full export:
+   *  1. Asks `main.ts` for all token data via `EXPORT_ALL`.
+   *  2. On response, builds the CSS file set with `buildAllFiles`, zips it
+   *     with JSZip, and triggers a browser download.
+   *
+   * Guards:
+   *  - `exportInFlight` ref blocks overlapping clicks so we never register
+   *    two `once()` handlers at the same time.
+   *  - A `EXPORT_TIMEOUT_MS` timer resets the button if `EXPORTED_ALL`
+   *    never comes back (e.g. an error in the plugin sandbox).
+   *  - The button label is flashed to a status string and reverts via
+   *    `scheduleReset` so it can't get stuck on "Downloaded!".
+   */
+  const exportStylesHandler = useCallback(() => {
+    if (exportInFlight.current) return;
+    exportInFlight.current = true;
+    setExportButtonText(EXPORT_GENERATING_TITLE);
+
+    let timeoutId: number | undefined;
+    const finish = (text: string) => {
+      if (timeoutId) clearTimeout(timeoutId);
+      exportInFlight.current = false;
+      setExportButtonText(text);
+      if (text !== EXPORT_TITLE) {
+        scheduleReset('export', () => setExportButtonText(EXPORT_TITLE));
+      }
+    };
+
+    timeoutId = window.setTimeout(() => {
+      console.error('Export timed out waiting for EXPORTED_ALL');
+      finish(EXPORT_TITLE);
+    }, EXPORT_TIMEOUT_MS);
+
+    once('EXPORTED_ALL', async (payload: ExportPayload) => {
+      try {
+        const files = buildAllFiles(payload, rootTheme);
+        const zip = new JSZip();
+        for (const [name, content] of Object.entries(files)) {
+          zip.file(name, content);
+        }
+        const blob = await zip.generateAsync({ type: 'blob' });
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = buildArchiveName(payload.fileName);
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+        URL.revokeObjectURL(url);
+        finish(EXPORT_DONE_TITLE);
+      } catch (err) {
+        console.error('Failed to build styles zip', err);
+        finish(EXPORT_TITLE);
+      }
+    });
+
+    emit('EXPORT_ALL', { styleMode: selectedStyleMode });
+  }, [rootTheme, selectedStyleMode, scheduleReset]);
 
   useEffect(() => {
     emit('LOAD_MODES');
-    once('LOADED_MODES', ({ modes }) => {
-      const mode = Object.keys(modes)?.[0];
-      setModes(modes);
-      if (mode) {
-        setSelectedMode(Object.keys(modes)?.[0]);
+    once(
+      'LOADED_MODES',
+      ({
+        modes,
+        defaultModeId,
+        styleModes,
+        defaultStyleModeId,
+      }: {
+        modes: Record<string, string>;
+        defaultModeId?: string;
+        styleModes: Record<string, string>;
+        defaultStyleModeId?: string;
+      }) => {
+        setModes(modes);
+        const firstMode = Object.keys(modes)?.[0];
+        const initialMode = defaultModeId && modes[defaultModeId] ? defaultModeId : firstMode;
+        if (initialMode) setSelectedMode(initialMode);
+
+        setStyleModes(styleModes);
+        const firstStyle = Object.keys(styleModes)?.[0];
+        const initialStyle =
+          defaultStyleModeId && styleModes[defaultStyleModeId] ? defaultStyleModeId : firstStyle;
+        if (initialStyle) setSelectedStyleMode(initialStyle);
+
+        setModesLoading(false);
       }
-      setModesLoading(false);
-    });
-    on(
+    );
+
+    // `on()` from @create-figma-plugin/utilities returns its own teardown
+    // function. We capture each one as `off*` and call them in the effect
+    // cleanup so listeners don't stack on unmount / HMR re-mount.
+
+    /**
+     * Teardown for the `GENERATED_ROOT_VARIABLES` listener.
+     * Invoke to detach the handler from the plugin message bus.
+     */
+    const offRoot = on(
       'GENERATED_ROOT_VARIABLES',
-      ({ tokens }: { tokens: { token: string; value: string }[] }) => {
-        setColorVariables(
-          tokens.map((val) => {
-            if (typeof val === 'string') {
-              return val;
-            } else {
-              return`--${val.token}: ${val.value};`
-            }
-          })
-          .join(`\n`),
-        );
-      },
+      ({ tokens }: { tokens: (string | Token)[] }) => {
+        setColorVariables(formatTokens(tokens));
+      }
     );
-    on(
+
+    /**
+     * Teardown for the `GENERATED_MODE_VARIABLES` listener.
+     * Invoke to detach the handler from the plugin message bus.
+     */
+    const offMode = on(
       'GENERATED_MODE_VARIABLES',
-      ({ tokens }: { tokens: { token: string; value: string }[] }) => {
+      ({ tokens }: { tokens: Token[] }) => {
         setModeVariables(
-          tokens
-            .map(({ token, value }) => `--${token}: var(--${value});`)
-            .join(`\n`),
+          tokens.map(({ token, value }) => `--${token}: var(--${value});`).join('\n')
         );
-      },
+      }
     );
-    on(
+
+    /**
+     * Teardown for the `GENERATED_COMPONENT_VARIABLES` listener.
+     * Invoke to detach the handler from the plugin message bus.
+     */
+    const offComponent = on(
       'GENERATED_COMPONENT_VARIABLES',
-      ({ tokens }: { tokens: (string | { token: string; value: string })[] }) => {
-        setComponentVariables(
-          tokens
-            .map((val) => {
-              if (typeof val === 'string') {
-                return val;
-              } else {
-                return`--${val.token}: ${val.value};`
-              }
-            })
-            .join(`\n`),
-        );
-      },
+      ({ tokens }: { tokens: (string | Token)[] }) => {
+        setComponentVariables(formatTokens(tokens));
+      }
     );
-    on(
+
+    /**
+     * Teardown for the `GENERATED_OTHER_VARIABLES` listener.
+     * Invoke to detach the handler from the plugin message bus.
+     */
+    const offOther = on(
       'GENERATED_OTHER_VARIABLES',
-      ({ tokens }: { tokens: ({ token: string; value: string } | string)[] }) => {
-        setOtherVariables(
-          tokens
-            .map((val) => {
-              if (typeof val === 'string') {
-                return val;
-              } else {
-                return`--${val.token}: ${val.value};`
-              }
-            })
-            .join(`\n`),
-        );
-      },
+      ({ tokens }: { tokens: (string | Token)[] }) => {
+        setOtherVariables(formatTokens(tokens));
+      }
     );
-  }, [setModes, setSelectedMode]);
+
+    const timers = copyTimers.current;
+    return () => {
+      offRoot();
+      offMode();
+      offComponent();
+      offOther();
+      for (const id of Object.values(timers)) clearTimeout(id);
+    };
+  }, []);
 
   if (modesLoading) {
-    return <div style={{ width: '100%', height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center'}}>
-      <h3>Loading...</h3>
-    </div>
+    return (
+      <div class={styles.loading}>
+        <h3>Loading...</h3>
+      </div>
+    );
   }
 
   if (Object.keys(modes).length === 0) {
@@ -148,26 +300,25 @@ function Plugin() {
       <Container space="large">
         <VerticalSpace space="small" />
         <div>
-          <p>
           <h2>Heads up! 🙌</h2>
+          <p>
+            It looks like this plugin is running outside of the Unify Design System workspace.
           </p>
           <p>
-          It looks like this plugin is running outside of the Unify Design System workspace.
+            The Unify Design System provides shared styles, components, and tokens that this plugin depends on to work correctly.
           </p>
           <p>
-          The Unify Design System provides shared styles, components, and tokens that this plugin depends on to work correctly.
+            To make full use of its features, please open or install the plugin within a Figma file that’s applied with the Unify Design System.
+          </p>
+          <p>You can find setup instructions, access details, and more information here:</p>
+          <p>
+            👉 Learn more at{' '}
+            <a target="_blank" href="https://unifydesignsystem.com">
+              unifydesignsystem.com
+            </a>
           </p>
           <p>
-          To make full use of its features, please open or install the plugin within a Figma file that’s applied with the Unify Design System.
-          </p>
-          <p>
-          You can find setup instructions, access details, and more information here:
-          </p>
-          <p>
-          👉 Learn more at <a target="_blank" href="https://unifydesignsystem.com">unifydesignsystem.com</a>
-          </p>
-          <p>
-          If you’re unsure whether your current Figma file is part of Unify, reach out to your design system admin or check your team’s Unify documentation.
+            If you’re unsure whether your current Figma file is part of Unify, reach out to your design system admin or check your team’s Unify documentation.
           </p>
         </div>
         <VerticalSpace space="small" />
@@ -178,106 +329,148 @@ function Plugin() {
   return (
     <Container space="large">
       <VerticalSpace space="small" />
-      Mode:
+      {Object.keys(styleModes).length > 1 && (
+        <Fragment>
+          Style:
+          <VerticalSpace space="extraSmall" />
+          <Dropdown
+            placeholder="Select Style"
+            value={selectedStyleMode}
+            options={Object.entries(styleModes).map(([key, val]) => ({
+              text: val,
+              value: key,
+            }))}
+            onChange={(e) => setSelectedStyleMode(e.currentTarget.value)}
+          />
+          <VerticalSpace space="small" />
+        </Fragment>
+      )}
+      Default theme:
       <VerticalSpace space="extraSmall" />
       <Dropdown
-        placeholder="Select Mode"
-        value={selectedMode}
-        options={Object.entries(modes).map(([key, val]) => ({
-          text: val,
-          value: key,
-        }))}
-        onChange={(e) => setSelectedMode(e.currentTarget.value)}
+        value={rootTheme}
+        options={[
+          { text: 'Dark', value: 'dark' },
+          { text: 'Light', value: 'light' },
+        ]}
+        onChange={(e) => setRootTheme(e.currentTarget.value as DefaultMode)}
       />
       <VerticalSpace space="small" />
-      <Button fullWidth onClick={generateVariablesHandler}>
-        Generate
-      </Button>
-      <VerticalSpace space="large" />
-      Root variables:
-      <VerticalSpace space="extraSmall" />
-      <div class={styles.container}>
-        <TextboxMultiline
-          rows={10}
-          placeholder="Click on Generate"
-          value={colorVariables}
-        />
-      </div>
-      <VerticalSpace space="small" />
       <Button
-        disabled={
-          !colorVariables ||
-          colorVariables === GENERATING_TITLE ||
-          colorsCopyButtonText === COPIED_TITLE
-        }
-        onClick={copyColors}
+        fullWidth
+        disabled={exportButtonText === EXPORT_GENERATING_TITLE}
+        onClick={exportStylesHandler}
       >
-        {colorsCopyButtonText}
+        {exportButtonText}
       </Button>
       <VerticalSpace space="large" />
-      Mode variables:
-      <VerticalSpace space="extraSmall" />
-      <div class={styles.container}>
-        <TextboxMultiline
-          rows={10}
-          placeholder="Click on Generate"
-          value={modeVariables}
+      <Disclosure
+        open={inspectOpen}
+        onClick={() => setInspectOpen((v) => !v)}
+        title="Inspect variables"
+      >
+        <VerticalSpace space="small" />
+        Mode:
+        <VerticalSpace space="extraSmall" />
+        <Dropdown
+          placeholder="Select Mode"
+          value={selectedMode}
+          options={Object.entries(modes).map(([key, val]) => ({
+            text: val,
+            value: key,
+          }))}
+          onChange={(e) => setSelectedMode(e.currentTarget.value)}
         />
-      </div>
-      <VerticalSpace space="small" />
-      <Button
-        disabled={
-          !modeVariables ||
-          modeVariables === GENERATING_TITLE ||
-          modeCopyButtonText === COPIED_TITLE
-        }
-        onClick={copyModeTokens}
-      >
-        {modeCopyButtonText}
-      </Button>
-      <VerticalSpace space="large" />
+        <VerticalSpace space="small" />
+        <Button fullWidth secondary onClick={generateVariablesHandler}>
+          Generate
+        </Button>
+        <VerticalSpace space="large" />
+        Root variables:
+        <VerticalSpace space="extraSmall" />
+        <div class={styles.container}>
+          <TextboxMultiline
+            rows={10}
+            placeholder="Click on Generate"
+            value={colorVariables}
+          />
+        </div>
+        <VerticalSpace space="small" />
+        <Button
+          disabled={
+            !colorVariables ||
+            colorVariables === GENERATING_TITLE ||
+            colorsCopyButtonText === COPIED_TITLE
+          }
+          onClick={copyColors}
+        >
+          {colorsCopyButtonText}
+        </Button>
+        <VerticalSpace space="large" />
+        Mode variables:
+        <VerticalSpace space="extraSmall" />
+        <div class={styles.container}>
+          <TextboxMultiline
+            rows={10}
+            placeholder="Click on Generate"
+            value={modeVariables}
+          />
+        </div>
+        <VerticalSpace space="small" />
+        <Button
+          disabled={
+            !modeVariables ||
+            modeVariables === GENERATING_TITLE ||
+            modeCopyButtonText === COPIED_TITLE
+          }
+          onClick={copyModeTokens}
+        >
+          {modeCopyButtonText}
+        </Button>
+        <VerticalSpace space="large" />
         Component variables:
-      <VerticalSpace space="extraSmall" />
-      <div class={styles.container}>
-        <TextboxMultiline
-          rows={10}
-          placeholder="Click on Generate"
-          value={componentVariables}
-        />
-      </div>
-      <VerticalSpace space="small" />
-      <Button
-        disabled={
-          !componentVariables ||
-          componentVariables === GENERATING_TITLE ||
-          componentCopyButtonText === COPIED_TITLE
-        }
-        onClick={copyTokens}
-      >
-        {componentCopyButtonText}
-      </Button>
-      <VerticalSpace space="large" />
+        <VerticalSpace space="extraSmall" />
+        <div class={styles.container}>
+          <TextboxMultiline
+            rows={10}
+            placeholder="Click on Generate"
+            value={componentVariables}
+          />
+        </div>
+        <VerticalSpace space="small" />
+        <Button
+          disabled={
+            !componentVariables ||
+            componentVariables === GENERATING_TITLE ||
+            componentCopyButtonText === COPIED_TITLE
+          }
+          onClick={copyTokens}
+        >
+          {componentCopyButtonText}
+        </Button>
+        <VerticalSpace space="large" />
         Other variables:
-      <VerticalSpace space="extraSmall" />
-      <div class={styles.container}>
-        <TextboxMultiline
-          rows={10}
-          placeholder="Click on Generate"
-          value={otherVariables}
-        />
-      </div>
-      <VerticalSpace space="small" />
-      <Button
-        disabled={
-          !otherVariables ||
-          otherVariables === GENERATING_TITLE ||
-          otherCopyButtonText === COPIED_TITLE
-        }
-        onClick={copyOther}
-      >
-        {otherCopyButtonText}
-      </Button>
-      <VerticalSpace space="small" />
+        <VerticalSpace space="extraSmall" />
+        <div class={styles.container}>
+          <TextboxMultiline
+            rows={10}
+            placeholder="Click on Generate"
+            value={otherVariables}
+          />
+        </div>
+        <VerticalSpace space="small" />
+        <Button
+          disabled={
+            !otherVariables ||
+            otherVariables === GENERATING_TITLE ||
+            otherCopyButtonText === COPIED_TITLE
+          }
+          onClick={copyOther}
+        >
+          {otherCopyButtonText}
+        </Button>
+        <VerticalSpace space="small" />
+      </Disclosure>
     </Container>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@create-figma-plugin/tsconfig",
   "compilerOptions": {
-    "typeRoots": ["node_modules/@figma", "node_modules/@types"]
+    "typeRoots": ["node_modules/@figma", "node_modules/@types"],
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION

<img width="520" height="304" alt="Screenshot 2026-05-15 at 11 47 10" src="https://github.com/user-attachments/assets/0879b9af-c00c-4c35-803f-4cfa8ac1560d" />
<img width="516" height="1224" alt="Screenshot 2026-05-15 at 11 47 20" src="https://github.com/user-attachments/assets/429ad581-cfd7-423d-bdef-21987cabf642" />


## Overview

Adds a primary **Export Styles** flow that produces a ready-to-use CSS bundle (zip) directly from Figma variables, alongside a refactor of the underlying token-collection logic in `main.ts` and a round of bug fixes in the UI.

Before this PR, users had to click **Generate** then copy each section manually into their codebase. Now one click downloads a complete `*-styles.zip` they can drop into a reablocks project.

> **Scope:** this PR covers only the plugin (`reablocks-figma-plugin`). Documentation in the **`gg/skills`** repo that describes the plugin export flow (the `unify-theme` skill) is updated in a separate PR in that repo.

## What's new

### Export Styles (primary action)

- New **Export Styles** button at the top of the plugin window.
- New **Default theme** dropdown — picks which theme (`Dark` / `Light`) gets emitted at `:root` vs. wrapped in `.theme-*` selectors.
- New **Style** dropdown — appears only when the Figma file has multiple Style modes (e.g. compact vs. comfortable typography).
- Produces a `<file-name>-styles.zip` containing:
  - `index.css` — entry point
  - `common.css` — resets, body, tooltip vars
  - `root.css` — concrete hexes + dimension pixels
  - `light.css` / `dark.css` — mode tokens (default-mode at `:root`, others wrapped in `.theme-*` / `[data-theme=*]`)
  - One `<mode>.css` file per extra Figma mode found
  - `tw.css` — Tailwind v4 `@theme inline` config
- Empty light/dark CSS files include an explanatory comment when the corresponding mode isn't found in the Figma file.

### Inspect Variables (existing flow, moved)

The previous "Generate / Copy per section" workflow is preserved but moved behind an **Inspect variables** disclosure so it doesn't clutter the primary path.

## Architecture changes

### New: `src/exporter.ts`

Pure, side-effect-free module that turns an `ExportPayload` into a `Record<filename, css>` map. No Figma API coupling, easy to reason about and test. Exposes:

- `buildAllFiles(payload, defaultMode)` — top-level entry
- `buildRootCss`, `buildDefaultModeCss`, `buildWrappedModeCss`, `buildTwCss` — section builders
- `buildArchiveName(fileName)` — slugifies the Figma file name into a safe zip filename

### Refactor: `src/main.ts`

- Extracted shared collection helpers (`collectRootColors`, `collectRootDimensions`, `collectModeTokens`, `collectComponentTokens`, `collectTypography`) so the four per-event handlers and the new `EXPORT_ALL` handler all share one implementation. Removes ~150 lines of duplication that would have caused per-event vs. export divergence over time.
- Added `isAlias` / `isRgba` type guards and dropped every `as any` / `as VariableAlias` / `as number` cast from the file.
- Cached variable collections in a `Map<name, VariableCollection>` populated once per handler invocation (one fewer Figma round-trip per token).
- Renamed `getNestedVariable` → `resolveAlias`; behavior unchanged.

### UI bug fixes: `src/ui.tsx`

- **Initial mode/style selection was hardcoded to index 0** — the previous code did `setSelectedMode(Object.keys(modes)[0])` and ignored the Figma collection's `defaultModeId`. If a file had, say, Dark configured as the collection's default but Light happened to be first in iteration order, the inspector would resolve aliases against Light until the user manually re-selected. Fixed by having `main.ts` emit `defaultModeId` (and `defaultStyleModeId`) on `LOADED_MODES`, and the UI now prefers that id when valid, falling back to `Object.keys()[0]` only when the default is missing from the modes map. Same fix applied to the new Style dropdown.
- **Listener leak on export failure** — `once('EXPORTED_ALL', …)` was registered inside the click handler. If `main.ts` errored, the listener stayed registered and the button stayed permanently disabled. Now guarded by an `exportInFlight` ref plus a 30s timeout that resets the button if no response arrives.
- **Listener leak on unmount / HMR** — `on()` calls in `useEffect` had no cleanup, so listeners stacked across re-mounts. Now capture each unsubscribe (`offRoot`, `offMode`, `offComponent`, `offOther`) and call them in the effect cleanup.
- **`setTimeout` cleanup** — copy buttons used unmanaged timers. Replaced with a `scheduleReset` helper that cancels the prior timer for a given key and clears all timers on unmount.
- **Invalid HTML** — `<h2>` was nested inside `<p>` in the empty state. Replaced with unwrapped block elements so browsers don't auto-close the `<p>`.
- **Naming** — renamed `defaultMode` state → `rootTheme` to disambiguate from the Figma "mode" variable in the inspector.
- Moved loading-state inline `style` into `styles.css` as a `.loading` class.
- Added `formatTokens(...)` helper to deduplicate the four near-identical map+join blocks that turn `(string | Token)[]` into a CSS-variable text block.

## Documentation

- **README.md** — replaced the old "Copy Colors / Copy Themes" instructions with a full **Export Styles** section: pre-requisites, click-by-click flow, a table describing each file in the zip, and a "Using the bundle in your project" snippet. The Inspect Variables flow is documented as a secondary option.
- **JSDoc** — every function in `ui.tsx` now has a brief doc comment, plus the `off*` unsubscribe consts have one-liners explaining what calling them does. Public builders in `exporter.ts` have one-line headers describing the file they produce.

## Dependencies

- **Added:** `jszip ^3.10.1` — used in the browser to assemble the export zip.
- **`tsconfig.json`** — set `skipLibCheck: true`. Required because jszip's types reference Node-only `Buffer` / `NodeJS` namespaces, and `@figma/plugin-typings` collides with `lib.dom.d.ts` on `console` / `fetch` re-declarations.

## Files touched

| File | Change |
| --- | --- |
| `src/main.ts` | Refactor — shared helpers, type guards, no behavior change |
| `src/ui.tsx` | New export flow, listener/timer cleanup, JSDoc, HTML fix, rename |
| `src/exporter.ts` | **New** — pure CSS-bundle builder |
| `src/styles.css` + `.d.ts` | Added `.loading` class |
| `tsconfig.json` | `skipLibCheck: true`, trailing newline |
| `package.json` | `jszip` dependency |
| `README.md` | Documented the new export flow |


